### PR TITLE
DETAIL-VIEW - a detailed list mode

### DIFF
--- a/lib/mescal-cli/cli.rb
+++ b/lib/mescal-cli/cli.rb
@@ -28,12 +28,27 @@ END
       when "run" then run
       when "ssh" then ssh
       when "list" then list
+      when "longlist" then longlist
       when "kill" then kill(ARGV[1])
       end
     end
 
     def list
       tp Task.list(@client), {id: {width: 48}}, :image, :cmd, :state
+    end
+    
+    def longlist
+      Task.list(@client).each do |task|
+        str = <<-TASK
+          ---------------------------------------------------------
+               id: #{task.id}
+            image: #{task.image}
+              cmd: #{task.cmd}
+            state: #{task.state}
+          started: #{Time.at(task.started/1000)}
+        TASK
+        puts str.gsub(/^\s{10}/,'')
+      end
     end
 
     def run

--- a/lib/mescal-cli/cli.rb
+++ b/lib/mescal-cli/cli.rb
@@ -45,7 +45,7 @@ END
             image: #{task.image}
               cmd: #{task.cmd}
             state: #{task.state}
-          started: #{Time.at(task.started/1000)}
+          started: #{Time.at(task.started/1000) rescue 'unknown'}
         TASK
         puts str.gsub(/^\s{10}/,'')
       end

--- a/lib/mescal-cli/task.rb
+++ b/lib/mescal-cli/task.rb
@@ -28,7 +28,7 @@ module MescalCli
       end
     end
 
-    def initialize(client, id, image, cmd, started)
+    def initialize(client, id, image, cmd, started = nil)
       @client, @id, @image, @cmd, @started = client, id, image, cmd, started
     end
 

--- a/lib/mescal-cli/task.rb
+++ b/lib/mescal-cli/task.rb
@@ -1,6 +1,6 @@
 module MescalCli
   class Task
-    attr_reader :id, :image, :cmd, :slave_id
+    attr_reader :id, :image, :cmd, :slave_id, :started
     attr_accessor :state
 
     def self.create(client, image, cmd, cpus, mem)
@@ -13,7 +13,7 @@ module MescalCli
       resp = client.task.list
       obj = MultiJson.load(resp)
       obj.map do |jsTask|
-        t = Task.new(nil, jsTask['id'], jsTask['image'], jsTask['cmd'])
+        t = Task.new(nil, jsTask['id'], jsTask['image'], jsTask['cmd'], jsTask['createdAt'])
         t.state = jsTask['state']
         t
       end
@@ -28,8 +28,8 @@ module MescalCli
       end
     end
 
-    def initialize(client, id, image, cmd)
-      @client, @id, @image, @cmd = client, id, image, cmd
+    def initialize(client, id, image, cmd, started)
+      @client, @id, @image, @cmd, @started = client, id, image, cmd, started
     end
 
     def update!

--- a/lib/mescal-cli/version.rb
+++ b/lib/mescal-cli/version.rb
@@ -1,3 +1,3 @@
 module MescalCli
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
The IMAGE column in "mescal list" is essentially useless to us, since the only part we care about is the part that is always truncated.  Ditto CMD.   And a "started" timestamp is incredibly helpful as well.
